### PR TITLE
Error creating bean with name 'liquibase' defined in class path resource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<name>telegram-bot</name>
 	<description>Telegram Bot with Spring Boot</description>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -33,7 +33,12 @@
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<scope>runtime</scope>
+			<version>42.7.2</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.liquibase</groupId>
+			<artifactId>liquibase-core</artifactId>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/pro/sky/telegrambot/listener/TelegramBotUpdatesListener.java
+++ b/src/main/java/pro/sky/telegrambot/listener/TelegramBotUpdatesListener.java
@@ -3,21 +3,39 @@ package pro.sky.telegrambot.listener;
 import com.pengrad.telegrambot.TelegramBot;
 import com.pengrad.telegrambot.UpdatesListener;
 import com.pengrad.telegrambot.model.Update;
+import com.pengrad.telegrambot.request.SendMessage;
+import com.pengrad.telegrambot.response.SendResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import pro.sky.telegrambot.model.NotificationTask;
+import pro.sky.telegrambot.repositories.NotificationTasRepository;
 
 import javax.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class TelegramBotUpdatesListener implements UpdatesListener {
 
-    private Logger logger = LoggerFactory.getLogger(TelegramBotUpdatesListener.class);
+    private static final Logger logger = LoggerFactory.getLogger(TelegramBotUpdatesListener.class);
 
-    @Autowired
-    private TelegramBot telegramBot;
+    private static final String WELCOME_MESSAGE = "Привет!" +
+            " Введи по порядку время и название задачи в формате: 01.01.2022 20:00 Сделать домашнюю работу";
+    private static final Pattern PATTERN = Pattern.compile("([0-9\\.\\:\\s]{16})(\\s)([\\W+]+)");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER= DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm");
+    private final TelegramBot telegramBot;
+    private final NotificationTasRepository notificationTasRepository;
+
+
+    public TelegramBotUpdatesListener(TelegramBot telegramBot, NotificationTasRepository notificationTasRepository) {
+        this.telegramBot = telegramBot;
+        this.notificationTasRepository = notificationTasRepository;
+    }
 
     @PostConstruct
     public void init() {
@@ -28,9 +46,60 @@ public class TelegramBotUpdatesListener implements UpdatesListener {
     public int process(List<Update> updates) {
         updates.forEach(update -> {
             logger.info("Processing update: {}", update);
-            // Process your updates here
+            var message = update.message();
+            if (message != null) {
+                var messageText = update.message().text();
+                var chatId = update.message().chat().id();
+
+                if (messageText != null && messageText.equals("/start")) {
+                    sendMessage(chatId, WELCOME_MESSAGE);
+                } else {
+                    splitMessage(chatId, messageText);
+                }
+            }
         });
         return UpdatesListener.CONFIRMED_UPDATES_ALL;
+    }
+
+    public void splitMessage(Long chat, String message) {
+        Matcher matcher = PATTERN.matcher(message);
+
+        try {
+            if (!matcher.matches()) {
+                throw new IllegalStateException("Not a perfect String");
+            }
+        } catch (IllegalStateException e) {
+            logger.error("Could not parse MAT date {}, expected format [{}].", matcher, message);
+            sendMessage(chat, "Недопустимые символы");
+            return;
+        }
+
+        var dateTime = matcher.group(1);
+        var reminderText = matcher.group(3);
+        LocalDateTime reminderClock;
+        try {
+            reminderClock = LocalDateTime.parse(dateTime, DATE_TIME_FORMATTER);
+        } catch (DateTimeParseException e) {
+            logger.error("Could not parse MAT date {}, expected format [{}].", dateTime, DATE_TIME_FORMATTER);
+            sendMessage(chat, "Неправильный формат даты");
+            return;
+        }
+
+        NotificationTask task = new NotificationTask();
+        task.setChatId(chat);
+        task.setTaskText(reminderText);
+        task.setTaskClock(reminderClock);
+        notificationTasRepository.save(task);
+        logger.info("Task has been saved {}", task);
+        sendMessage(chat, "Задача добавлена");
+    }
+
+    private void sendMessage(Long chat, String text) {
+        SendMessage message = new SendMessage(chat, text);
+
+        SendResponse response = telegramBot.execute(message);
+        logger.info("Response: {}", response.isOk());
+        logger.info("Error code: {}", response.errorCode());
     }
 
 }

--- a/src/main/java/pro/sky/telegrambot/model/NotificationTask.java
+++ b/src/main/java/pro/sky/telegrambot/model/NotificationTask.java
@@ -1,0 +1,77 @@
+package pro.sky.telegrambot.model;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "notification_task")
+public class NotificationTask {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    //@Column(name = "chat_id")
+    private long chatId;
+    //@Column(name = "task_text")
+    private String taskText;
+    //@Column(name = "task_clock")
+    private LocalDateTime taskClock;
+
+    public NotificationTask() {
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public long getChatId() {
+        return chatId;
+    }
+
+    public void setChatId(long chatId) {
+        this.chatId = chatId;
+    }
+
+    public String getTaskText() {
+        return taskText;
+    }
+
+    public void setTaskText(String taskText) {
+        this.taskText = taskText;
+    }
+
+    public LocalDateTime getTaskClock() {
+        return taskClock;
+    }
+
+    public void setTaskClock(LocalDateTime taskClock) {
+        this.taskClock = taskClock;
+    }
+
+    @Override
+    public String toString() {
+        return "NotificationTask{" +
+                "id=" + id +
+                ", chatId=" + chatId +
+                ", taskText='" + taskText + '\'' +
+                ", taskClock=" + taskClock +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NotificationTask that = (NotificationTask) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/src/main/java/pro/sky/telegrambot/notification/NotificationTaskScheduler.java
+++ b/src/main/java/pro/sky/telegrambot/notification/NotificationTaskScheduler.java
@@ -1,0 +1,40 @@
+package pro.sky.telegrambot.notification;
+
+import com.pengrad.telegrambot.TelegramBot;
+import com.pengrad.telegrambot.request.SendMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import pro.sky.telegrambot.listener.TelegramBotUpdatesListener;
+import pro.sky.telegrambot.repositories.NotificationTasRepository;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+public class NotificationTaskScheduler {
+
+    private final static Logger logger = LoggerFactory.getLogger(NotificationTaskScheduler.class);
+
+    private final TelegramBot telegramBot;
+    private final NotificationTasRepository repository;
+
+    public NotificationTaskScheduler(TelegramBot telegramBot, NotificationTasRepository repository) {
+        this.telegramBot = telegramBot;
+        this.repository = repository;
+    }
+
+    @Scheduled(cron = "0 0/1 * * * *")
+    public void sendAndDeleteNotification(){
+        repository.findNotificationTaskByTaskClock(LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES))
+                .forEach(task -> {
+                    telegramBot.execute(new SendMessage(task.getChatId(), task.getTaskText()));
+                    logger.info("Message has been sent");
+                    repository.deleteById(task.getId());
+                });
+
+
+
+    }
+}

--- a/src/main/java/pro/sky/telegrambot/repositories/NotificationTasRepository.java
+++ b/src/main/java/pro/sky/telegrambot/repositories/NotificationTasRepository.java
@@ -1,0 +1,11 @@
+package pro.sky.telegrambot.repositories;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import pro.sky.telegrambot.model.NotificationTask;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface NotificationTasRepository extends JpaRepository<NotificationTask, Long> {
+    List<NotificationTask> findNotificationTaskByTaskClock(LocalDateTime time);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,8 @@
-spring.datasource.url=
-spring.datasource.username=
-spring.datasource.password=
-telegram.bot.token=
+spring.datasource.url=jdbc:postgresql://localhost:5432/dbtelegrambot
+spring.datasource.username=telegram
+spring.datasource.password=telegram1234
+telegram.bot.token=7398220456:AAFuMhlDoX-w6vPAyYxf1cHOEHFud7wJeFg
+spring.liquibase.change-log=classpath:liquibase/changelog-master.yml
+# Hibernate ddl auto (create, create-drop, validate, update)
+spring.jpa.hibernate.ddl-auto=validate
+spring.jpa.show-sql=true

--- a/src/main/resources/liquibase/changelog-master.yml
+++ b/src/main/resources/liquibase/changelog-master.yml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - include:
+      file: liquibase/scripts/telegram.sql

--- a/src/main/resources/liquibase/scripts/telegram.sql
+++ b/src/main/resources/liquibase/scripts/telegram.sql
@@ -1,0 +1,10 @@
+-- liquibase formatted sql
+
+-- changeset dkhan:1
+
+CREATE TABLE notification_task(
+id BIGSERIAL primary key,
+chat_id BIGINT,
+task_text VARCHAR,
+task_clock TIMESTAMP
+)


### PR DESCRIPTION
Не могу разобраться, почему идёт ошибка, при том, что таблица создаётся

C:\Users\Manager\.jdks\corretto-17.0.8.1\bin\java.exe "-javaagent:C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2023.2.2\lib\idea_rt.jar=4173:C:\Program Files\JetBrains\IntelliJ IDEA Community Edition 2023.2.2\bin" -Dfile.encoding=UTF-8 -classpath C:\Users\Manager\IdeaProjects\telegram-bot\target\classes;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter-web\2.6.5\spring-boot-starter-web-2.6.5.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter\2.6.5\spring-boot-starter-2.6.5.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot\2.6.5\spring-boot-2.6.5.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-autoconfigure\2.6.5\spring-boot-autoconfigure-2.6.5.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter-logging\2.6.5\spring-boot-starter-logging-2.6.5.jar;C:\Users\Manager\.m2\repository\ch\qos\logback\logback-classic\1.2.11\logback-classic-1.2.11.jar;C:\Users\Manager\.m2\repository\ch\qos\logback\logback-core\1.2.11\logback-core-1.2.11.jar;C:\Users\Manager\.m2\repository\org\apache\logging\log4j\log4j-to-slf4j\2.17.2\log4j-to-slf4j-2.17.2.jar;C:\Users\Manager\.m2\repository\org\apache\logging\log4j\log4j-api\2.17.2\log4j-api-2.17.2.jar;C:\Users\Manager\.m2\repository\org\slf4j\jul-to-slf4j\1.7.36\jul-to-slf4j-1.7.36.jar;C:\Users\Manager\.m2\repository\jakarta\annotation\jakarta.annotation-api\1.3.5\jakarta.annotation-api-1.3.5.jar;C:\Users\Manager\.m2\repository\org\yaml\snakeyaml\1.29\snakeyaml-1.29.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter-json\2.6.5\spring-boot-starter-json-2.6.5.jar;C:\Users\Manager\.m2\repository\com\fasterxml\jackson\core\jackson-databind\2.13.2\jackson-databind-2.13.2.jar;C:\Users\Manager\.m2\repository\com\fasterxml\jackson\core\jackson-annotations\2.13.2\jackson-annotations-2.13.2.jar;C:\Users\Manager\.m2\repository\com\fasterxml\jackson\core\jackson-core\2.13.2\jackson-core-2.13.2.jar;C:\Users\Manager\.m2\repository\com\fasterxml\jackson\datatype\jackson-datatype-jdk8\2.13.2\jackson-datatype-jdk8-2.13.2.jar;C:\Users\Manager\.m2\repository\com\fasterxml\jackson\datatype\jackson-datatype-jsr310\2.13.2\jackson-datatype-jsr310-2.13.2.jar;C:\Users\Manager\.m2\repository\com\fasterxml\jackson\module\jackson-module-parameter-names\2.13.2\jackson-module-parameter-names-2.13.2.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter-tomcat\2.6.5\spring-boot-starter-tomcat-2.6.5.jar;C:\Users\Manager\.m2\repository\org\apache\tomcat\embed\tomcat-embed-core\9.0.60\tomcat-embed-core-9.0.60.jar;C:\Users\Manager\.m2\repository\org\apache\tomcat\embed\tomcat-embed-el\9.0.60\tomcat-embed-el-9.0.60.jar;C:\Users\Manager\.m2\repository\org\apache\tomcat\embed\tomcat-embed-websocket\9.0.60\tomcat-embed-websocket-9.0.60.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-web\5.3.17\spring-web-5.3.17.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-beans\5.3.17\spring-beans-5.3.17.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-webmvc\5.3.17\spring-webmvc-5.3.17.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-aop\5.3.17\spring-aop-5.3.17.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-context\5.3.17\spring-context-5.3.17.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-expression\5.3.17\spring-expression-5.3.17.jar;C:\Users\Manager\.m2\repository\com\github\pengrad\java-telegram-bot-api\5.7.0\java-telegram-bot-api-5.7.0.jar;C:\Users\Manager\.m2\repository\com\google\code\gson\gson\2.8.9\gson-2.8.9.jar;C:\Users\Manager\.m2\repository\com\squareup\okhttp3\okhttp\3.14.9\okhttp-3.14.9.jar;C:\Users\Manager\.m2\repository\com\squareup\okio\okio\1.17.2\okio-1.17.2.jar;C:\Users\Manager\.m2\repository\com\squareup\okhttp3\logging-interceptor\3.14.9\logging-interceptor-3.14.9.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter-data-jpa\2.6.5\spring-boot-starter-data-jpa-2.6.5.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter-aop\2.6.5\spring-boot-starter-aop-2.6.5.jar;C:\Users\Manager\.m2\repository\org\aspectj\aspectjweaver\1.9.7\aspectjweaver-1.9.7.jar;C:\Users\Manager\.m2\repository\org\springframework\boot\spring-boot-starter-jdbc\2.6.5\spring-boot-starter-jdbc-2.6.5.jar;C:\Users\Manager\.m2\repository\com\zaxxer\HikariCP\4.0.3\HikariCP-4.0.3.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-jdbc\5.3.17\spring-jdbc-5.3.17.jar;C:\Users\Manager\.m2\repository\jakarta\transaction\jakarta.transaction-api\1.3.3\jakarta.transaction-api-1.3.3.jar;C:\Users\Manager\.m2\repository\jakarta\persistence\jakarta.persistence-api\2.2.3\jakarta.persistence-api-2.2.3.jar;C:\Users\Manager\.m2\repository\org\hibernate\hibernate-core\5.6.7.Final\hibernate-core-5.6.7.Final.jar;C:\Users\Manager\.m2\repository\org\jboss\logging\jboss-logging\3.4.3.Final\jboss-logging-3.4.3.Final.jar;C:\Users\Manager\.m2\repository\net\bytebuddy\byte-buddy\1.11.22\byte-buddy-1.11.22.jar;C:\Users\Manager\.m2\repository\antlr\antlr\2.7.7\antlr-2.7.7.jar;C:\Users\Manager\.m2\repository\org\jboss\jandex\2.4.2.Final\jandex-2.4.2.Final.jar;C:\Users\Manager\.m2\repository\com\fasterxml\classmate\1.5.1\classmate-1.5.1.jar;C:\Users\Manager\.m2\repository\org\hibernate\common\hibernate-commons-annotations\5.1.2.Final\hibernate-commons-annotations-5.1.2.Final.jar;C:\Users\Manager\.m2\repository\org\glassfish\jaxb\jaxb-runtime\2.3.6\jaxb-runtime-2.3.6.jar;C:\Users\Manager\.m2\repository\org\glassfish\jaxb\txw2\2.3.6\txw2-2.3.6.jar;C:\Users\Manager\.m2\repository\com\sun\istack\istack-commons-runtime\3.0.12\istack-commons-runtime-3.0.12.jar;C:\Users\Manager\.m2\repository\com\sun\activation\jakarta.activation\1.2.2\jakarta.activation-1.2.2.jar;C:\Users\Manager\.m2\repository\org\springframework\data\spring-data-jpa\2.6.3\spring-data-jpa-2.6.3.jar;C:\Users\Manager\.m2\repository\org\springframework\data\spring-data-commons\2.6.3\spring-data-commons-2.6.3.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-orm\5.3.17\spring-orm-5.3.17.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-tx\5.3.17\spring-tx-5.3.17.jar;C:\Users\Manager\.m2\repository\org\slf4j\slf4j-api\1.7.36\slf4j-api-1.7.36.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-aspects\5.3.17\spring-aspects-5.3.17.jar;C:\Users\Manager\.m2\repository\org\postgresql\postgresql\42.7.2\postgresql-42.7.2.jar;C:\Users\Manager\.m2\repository\org\checkerframework\checker-qual\3.42.0\checker-qual-3.42.0.jar;C:\Users\Manager\.m2\repository\org\liquibase\liquibase-core\4.5.0\liquibase-core-4.5.0.jar;C:\Users\Manager\.m2\repository\javax\xml\bind\jaxb-api\2.3.1\jaxb-api-2.3.1.jar;C:\Users\Manager\.m2\repository\javax\activation\javax.activation-api\1.2.0\javax.activation-api-1.2.0.jar;C:\Users\Manager\.m2\repository\jakarta\xml\bind\jakarta.xml.bind-api\2.3.3\jakarta.xml.bind-api-2.3.3.jar;C:\Users\Manager\.m2\repository\jakarta\activation\jakarta.activation-api\1.2.2\jakarta.activation-api-1.2.2.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-core\5.3.17\spring-core-5.3.17.jar;C:\Users\Manager\.m2\repository\org\springframework\spring-jcl\5.3.17\spring-jcl-5.3.17.jar pro.sky.telegrambot.TelegramBotApplication

  .   ____          _            __ _ _
 /\\ / ___'_ __ _ _(_)_ __  __ _ \ \ \ \
( ( )\___ | '_ | '_| | '_ \/ _` | \ \ \ \
 \\/  ___)| |_)| | | | | || (_| |  ) ) ) )
  '  |____| .__|_| |_|_| |_\__, | / / / /
 =========|_|==============|___/=/_/_/_/
 :: Spring Boot ::                (v2.6.5)

2024-06-02 12:10:13.421  INFO 14292 --- [           main] p.s.telegrambot.TelegramBotApplication   : Starting TelegramBotApplication using Java 17.0.8.1 on DESKTOP-IFMUIK0 with PID 14292 (C:\Users\Manager\IdeaProjects\telegram-bot\target\classes started by Manager in C:\Users\Manager\IdeaProjects\telegram-bot)
2024-06-02 12:10:13.425  INFO 14292 --- [           main] p.s.telegrambot.TelegramBotApplication   : No active profile set, falling back to 1 default profile: "default"
2024-06-02 12:10:14.468  INFO 14292 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Bootstrapping Spring Data JPA repositories in DEFAULT mode.
2024-06-02 12:10:14.541  INFO 14292 --- [           main] .s.d.r.c.RepositoryConfigurationDelegate : Finished Spring Data repository scanning in 62 ms. Found 1 JPA repository interfaces.
2024-06-02 12:10:15.612  INFO 14292 --- [           main] o.s.b.w.embedded.tomcat.TomcatWebServer  : Tomcat initialized with port(s): 8080 (http)
2024-06-02 12:10:15.628  INFO 14292 --- [           main] o.apache.catalina.core.StandardService   : Starting service [Tomcat]
2024-06-02 12:10:15.628  INFO 14292 --- [           main] org.apache.catalina.core.StandardEngine  : Starting Servlet engine: [Apache Tomcat/9.0.60]
2024-06-02 12:10:15.812  INFO 14292 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2024-06-02 12:10:15.813  INFO 14292 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 2264 ms
2024-06-02 12:10:16.234  INFO 14292 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Starting...
2024-06-02 12:10:16.495  INFO 14292 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start completed.
2024-06-02 12:10:16.755  INFO 14292 --- [           main] liquibase.database                       : Set default schema name to public
2024-06-02 12:10:16.903  INFO 14292 --- [           main] liquibase.lockservice                    : Successfully acquired change log lock
2024-06-02 12:10:17.233  INFO 14292 --- [           main] liquibase.changelog                      : Reading from public.databasechangelog
2024-06-02 12:10:17.251  INFO 14292 --- [           main] liquibase.lockservice                    : Successfully released change log lock
2024-06-02 12:10:17.252  WARN 14292 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' defined in class path resource [org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration$LiquibaseConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.ValidationFailedException: Validation Failed:
     1 change sets check sum
          liquibase/scripts/telegram.sql::1::dkhan was: 8:c069f898c4cdaf95d8aad8eb15f0a0c5 but is now: 8:ab00a86b307cd5bcf6142bc018293fe8

2024-06-02 12:10:17.253  INFO 14292 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown initiated...
2024-06-02 12:10:17.263  INFO 14292 --- [           main] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Shutdown completed.
2024-06-02 12:10:17.267  INFO 14292 --- [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
2024-06-02 12:10:17.287  INFO 14292 --- [           main] ConditionEvaluationReportLoggingListener : 

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2024-06-02 12:10:17.315 ERROR 14292 --- [           main] o.s.boot.SpringApplication               : Application run failed

org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'liquibase' defined in class path resource [org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration$LiquibaseConfiguration.class]: Invocation of init method failed; nested exception is liquibase.exception.ValidationFailedException: Validation Failed:
     1 change sets check sum
          liquibase/scripts/telegram.sql::1::dkhan was: 8:c069f898c4cdaf95d8aad8eb15f0a0c5 but is now: 8:ab00a86b307cd5bcf6142bc018293fe8

	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1804) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:620) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:542) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:335) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:234) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:333) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:322) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:208) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1154) ~[spring-context-5.3.17.jar:5.3.17]
	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:908) ~[spring-context-5.3.17.jar:5.3.17]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583) ~[spring-context-5.3.17.jar:5.3.17]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:145) ~[spring-boot-2.6.5.jar:2.6.5]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:740) ~[spring-boot-2.6.5.jar:2.6.5]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:415) ~[spring-boot-2.6.5.jar:2.6.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:303) ~[spring-boot-2.6.5.jar:2.6.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1312) ~[spring-boot-2.6.5.jar:2.6.5]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1301) ~[spring-boot-2.6.5.jar:2.6.5]
	at pro.sky.telegrambot.TelegramBotApplication.main(TelegramBotApplication.java:12) ~[classes/:na]
Caused by: liquibase.exception.ValidationFailedException: Validation Failed:
     1 change sets check sum
          liquibase/scripts/telegram.sql::1::dkhan was: 8:c069f898c4cdaf95d8aad8eb15f0a0c5 but is now: 8:ab00a86b307cd5bcf6142bc018293fe8

	at liquibase.changelog.DatabaseChangeLog.validate(DatabaseChangeLog.java:299) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Liquibase.lambda$update$1(Liquibase.java:231) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Scope.lambda$child$0(Scope.java:177) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Scope.child(Scope.java:186) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Scope.child(Scope.java:176) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Scope.child(Scope.java:155) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Liquibase.runInScope(Liquibase.java:2404) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Liquibase.update(Liquibase.java:211) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.Liquibase.update(Liquibase.java:197) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.integration.spring.SpringLiquibase.performUpdate(SpringLiquibase.java:314) ~[liquibase-core-4.5.0.jar:na]
	at liquibase.integration.spring.SpringLiquibase.afterPropertiesSet(SpringLiquibase.java:269) ~[liquibase-core-4.5.0.jar:na]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1863) ~[spring-beans-5.3.17.jar:5.3.17]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1800) ~[spring-beans-5.3.17.jar:5.3.17]
	... 18 common frames omitted


Process finished with exit code 1
